### PR TITLE
Map-veto speedups

### DIFF
--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -375,18 +375,18 @@ class CSGO(commands.Cog):
             self.veto_image.construct_veto_image(map_list, veto_image_fp,
                                                  is_vetoed=is_vetoed, spacing=25)
             embed = await get_embed(current_team_captain, temp_channel)
-            await message.edit(embed=embed)
-            await message.clear_reaction(emoji_bank[vetoed_map_index + 1])
+            await asyncio.gather(message.edit(embed=embed),
+                                 message.clear_reaction(emoji_bank[vetoed_map_index + 1]))
 
             num_maps_left -= 1
 
         map_list = list(filter(lambda map_name: not is_vetoed[map_list.index(map_name)], map_list))
 
-        await message.clear_reactions()
         chosen_map = map_list[0]
         chosen_map_embed = await get_chosen_map_embed(chosen_map)
-        await message.edit(embed=chosen_map_embed)
-        await temp_channel.delete()
+        await asyncio.gather(message.clear_reactions(),
+                             message.edit(embed=chosen_map_embed),
+                             temp_channel.delete())
 
         return map_list
 

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -336,7 +336,9 @@ class CSGO(commands.Cog):
             chosen_map_file_name = chosen_map + self.veto_image.image_extension
             chosen_map_fp = os.path.join(
                 self.veto_image.map_images_fp, chosen_map_file_name)
-            attachment = discord.File(chosen_map_fp, chosen_map_file_name)
+            percentage = 0.25
+            VetoImage.resize(chosen_map_fp, percentage, output_fp=veto_image_fp)
+            attachment = discord.File(veto_image_fp, chosen_map_file_name)
             image_message = await temp_channel.send(file=attachment)
             chosen_map_image_url = image_message.attachments[0].url
             map_chosen_embed = discord.Embed(title=f'The chosen map is ```{chosen_map}```',

--- a/utils/veto_image.py
+++ b/utils/veto_image.py
@@ -56,6 +56,37 @@ class VetoImage:
             self._image_extension = '.' + value
         else:
             self._image_extension = value
+    
+    @staticmethod
+    def resize(image, percentage, output_fp=None):
+        '''Resizes the image based on the percentage provided
+
+        The aspect ratio will be preserved
+
+        Attributes
+        -----------
+        image: Union[:class:`str`, :class:`PIL.Image`]
+            The filepath of the image or the image object itself
+        percentage: :class:`float`
+            The percentage size of the new image e.g 0.5 will reduce the size
+            of the image by half
+        output_fp: Optional[:class:`str`]
+            If specified the image will be saved at the file path specified
+        '''
+
+        if isinstance(image, str):
+            image = Image.open(image)
+
+        image_width, image_height = image.size
+        new_size = (image_width * percentage,
+                    image_height * percentage)
+        new_size = tuple(map(int, new_size))
+        image = image.resize(new_size)
+
+        if output_fp:
+            image.save(output_fp)
+        
+        return image
 
     def __crop_map_images(self):
         '''Creates the map icon assets by cropping them and placing the
@@ -66,15 +97,11 @@ class VetoImage:
                 self.map_images_fp, image_file_name))
             image_width, image_height = image.size
 
+            percentage = 0.25
             crop_coodinates = (0, image_height / 3, image_width,
                                image_height * 2 / 3)
             map_strip = image.crop(crop_coodinates)
-
-            percentage = 0.25
-            image_width, image_height = map_strip.size
-            new_size = (int(image_width * percentage),
-                        int(image_height * percentage))
-            map_strip = map_strip.resize(new_size)
+            map_strip = VetoImage.resize(map_strip, percentage)
 
             map_strip.save(os.path.join(self.assets_fp, image_file_name))
 


### PR DESCRIPTION
Make map-veto more responsive by:
- Decreasing chosen map image size
- Making parts of the code more asynchronous