### PR TITLE
Added support for Multiple Servers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,8 +4,9 @@ import logging
 from databases import Database
 from discord.ext import commands
 from utils.server import WebServer
+from utils.csgo_server import CSGOServer
 
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 
 
 class Discord_10man(commands.Bot):
@@ -14,10 +15,13 @@ class Discord_10man(commands.Bot):
         super().__init__(command_prefix='.', case_insensitive=True, description='A bot to run CSGO PUGS.',
                          help_command=commands.DefaultHelpCommand(verify_checks=False))
         self.token = config['discord_token']
-        self.servers = config['servers']
+        self.servers: [CSGOServer] = []
+        for i, server in enumerate(config['servers']):
+            self.servers.append(CSGOServer(i, server['server_address'], server['server_port'], server['server_password'], server['RCON_password']))
         self.web_server = WebServer(bot=self)
         self.dev = False
         self.version = __version__
+        # TODO: Change to just CTX
         self.queue_voice_channel = None
         self.queue_text_channel = None
 

--- a/checks.py
+++ b/checks.py
@@ -1,6 +1,7 @@
 from databases import Database
 from discord.ext import commands
 
+
 async def voice_channel(ctx):
     if ctx.author.voice is None:
         raise commands.CommandError(message='You must be in a voice channel.')
@@ -28,4 +29,15 @@ async def linked_accounts(ctx):
                 error_message += f'<@{member.id}> '
             error_message += f'must connect their steam account with the command ```{ctx.bot.command_prefix}link <Steam Profile URL>```'
             raise commands.CommandError(message=error_message)
+    return True
+
+
+async def available_server(ctx):
+    available: bool = False
+    for server in ctx.bot.servers:
+        if server.available:
+            available = True
+            break
+    if not available:
+        raise commands.CommandError(message='There are no servers available')
     return True

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -197,11 +197,9 @@ class CSGO(commands.Cog):
                 'players': team2_steamIDs
             },
             'cvars': {
-                'get5_event_api_url': f'http://79.97.192.229:{self.bot.web_server.port}/'
+                'get5_event_api_url': f'http://{self.bot.web_server.IP}:{self.bot.web_server.port}/'
             }
         }
-
-        # {self.bot.web_server.IP}
 
         with open('./match_config.json', 'w') as outfile:
             json.dump(match_config, outfile, ensure_ascii=False, indent=4)

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -60,9 +60,10 @@ class Setup(commands.Cog):
                       brief='Sends a message to the server to test RCON', usage='<message>')
     @commands.has_permissions(administrator=True)
     async def RCON_message(self, ctx, *, message):
-        test = valve.rcon.execute((self.bot.servers[0]["server_address"], self.bot.servers[0]["server_port"]),
-                                  self.bot.servers[0]["RCON_password"], f'say {message}')
-        print(test)
+        for server in self.bot.servers:
+            test_message = valve.rcon.execute((server.server_address, server.server_port), server.RCON_password,
+                                              f'say {message}')
+            print(f'Server #{server.id} | {test_message}')
 
     @RCON_message.error
     async def RCON_message_error(self, ctx, error):
@@ -76,9 +77,9 @@ class Setup(commands.Cog):
                       brief='Unbans everyone from the server', hidden=True)
     @commands.has_permissions(administrator=True)
     async def RCON_unban(self, ctx):
-        unban = valve.rcon.execute((self.bot.servers[0]["server_address"], self.bot.servers[0]["server_port"]),
-                                   self.bot.servers[0]["RCON_password"], 'removeallids')
-        print(unban)
+        for server in self.bot.servers:
+            unban = valve.rcon.execute((server.server_address, server.server_port), server.RCON_password, 'removeallids')
+            print(f'Server #{server.id} | {unban}')
 
     @RCON_unban.error
     async def RCON_unban_error(self, ctx, error):

--- a/utils/csgo_server.py
+++ b/utils/csgo_server.py
@@ -1,0 +1,31 @@
+class CSGOServer:
+    def __init__(self, identifier: int, server_address: str, server_port: int, server_password: str, RCON_password: str):
+        self.id = identifier
+        self.server_address: str = server_address
+        self.server_port: int = server_port
+        self.server_password: str = server_password
+        self.RCON_password: str = RCON_password
+        self.available: bool = True
+
+        self.ctx = None
+        self.channels = None
+        self.players = None
+        self.score_message = None
+        self.team_names = None
+
+    def get_context(self, ctx, channels: list, players: list, score_message):
+        self.ctx = ctx
+        self.channels = channels
+        self.players = players
+        self.score_message = score_message
+
+    def set_team_names(self, team_names: list):
+        self.team_names = team_names
+
+    def make_available(self):
+        self.available: bool = True
+        self.ctx = None
+        self.channels = None
+        self.players = None
+        self.score_message = None
+        self.team_names = None


### PR DESCRIPTION
When reading the config file, the bot creates objects for each server and when a server is being used it is marked as so. Added logic to properly send messages in the right place if there are multiple matches going on at once.