### PR TITLE
!link command 

### DIFF
--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -29,7 +29,8 @@ class Setup(commands.Cog):
                         REPLACE INTO users (discord_id, steam_id)
                         VALUES( :discord_id, :steam_id )
                         ''', {"discord_id": str(ctx.author), "steam_id": str(steamID.as_steam2_zero)})
-        await ctx.send(f'Connected {steamID.community_url}')
+        embed = discord.Embed(description=f'Connected {ctx.author.mention} \n `{steamID.as_steam2}`', color=0x00FF00)
+        await ctx.send(embed=embed)
 
     @link.error
     async def link_error(self, ctx: commands.Context, error: Exception):


### PR DESCRIPTION
!link command now returns the discord user's name and their steam id instead of another steam profile url link. 