### PR TITLE
Added Arguments for Pug Command to have random teams and/or map

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,7 @@ from typing import List
 from utils.server import WebServer
 from utils.csgo_server import CSGOServer
 
-__version__ = '1.1.2'
+__version__ = '1.2.0'
 __dev__ = 745000319942918303
 
 class Discord_10man(commands.Bot):

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -199,6 +199,9 @@ class CSGO(commands.Cog):
         await message.edit(content=message_text, embed=embed)
         await message.clear_reactions()
 
+        chosen_map_embed = await self.get_chosen_map_embed(map_arg)
+        await ctx.send(embed=chosen_map_embed)
+
         team1_steamIDs = []
         team2_steamIDs = []
 

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -416,8 +416,6 @@ class CSGO(commands.Cog):
         num_maps_left = len(map_list)
         current_team_captain = choice((team1_captain, team2_captain))
 
-        current_category = ctx.channel.category
-
         self.veto_image.construct_veto_image(map_list, veto_image_fp,
                                              is_vetoed=is_vetoed, spacing=25)
         embed = await get_embed(current_team_captain)

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -13,8 +13,7 @@ from bot import Discord_10man
 from databases import Database
 from datetime import date
 from discord.ext import commands, tasks
-from random import choice
-from random import randint
+from random import choice, shuffle, randint
 from typing import List
 from utils.csgo_server import CSGOServer
 from utils.veto_image import VetoImage
@@ -45,7 +44,31 @@ class CSGO(commands.Cog):
     @commands.check(checks.ten_players)
     @commands.check(checks.linked_accounts)
     @commands.check(checks.available_server)
-    async def pug(self, ctx: commands.Context):
+    async def pug(self, ctx: commands.Context, arg0: str = None, arg1: str = None):
+        random_teams: bool = False
+        map_arg: str = None
+        if arg0 is not None:
+            if arg0 == 'random':
+                random_teams = True
+                if arg1 is not None:
+                    if arg1.startswith('de_'):
+                        map_arg = arg1
+                        if map_arg not in current_map_pool:
+                            raise commands.CommandError(message=f'`{map_arg}` is not in Map Pool')
+                    else:
+                        raise commands.CommandError(message=f'Invalid Argument: `{arg1}`')
+            elif arg0.startswith('de_'):
+                map_arg = arg0
+                if map_arg not in current_map_pool:
+                    raise commands.CommandError(message=f'`{map_arg}` is not in Map Pool')
+                if arg1 is not None:
+                    if arg1 == 'random':
+                        random_teams = True
+                    else:
+                        raise commands.CommandError(message=f'Invalid Argument: `{arg1}`')
+            else:
+                raise commands.CommandError(message=f'Invalid Argument: `{arg0}`')
+
         # TODO: Refactor this mess
         db = Database('sqlite:///main.sqlite')
         await db.connect()
@@ -60,100 +83,116 @@ class CSGO(commands.Cog):
         players = players[0: 13]
         if self.bot.dev:
             players = [ctx.author] * 10
-        emojis = emoji_bank.copy()
-        del emojis[len(players) - 2:len(emojis)]
-        emojis_selected = []
-        team1 = []
-        team2 = []
-        team1_captain = players[randint(0, len(players) - 1)]
-        team1.append(team1_captain)
-        players.remove(team1_captain)
-        team2_captain = players[randint(0, len(players) - 1)]
-        team2.append(team2_captain)
-        players.remove(team2_captain)
 
-        current_team_player_select = 1
-
-        current_captain = team1_captain
-        player_veto_count = 0
-
-        message = await ctx.send('10 man time\nLoading player selection...')
-        for emoji in emojis:
-            await message.add_reaction(emoji)
-
-        emoji_remove = []
-
-        while len(players) > 0:
-            message_text = ''
-            players_text = ''
-
-            if current_team_player_select == 1:
-                message_text += f'<@{team1_captain.id}>'
-                current_captain = team1_captain
-            elif current_team_player_select == 2:
-                message_text += f'<@{team2_captain.id}>'
-                current_captain = team2_captain
-
-            message_text += f' select {player_veto[player_veto_count]}\n'
-            message_text += 'You have 60 seconds to choose your player(s)\n'
-
-            i = 0
-            for player in players:
-                players_text += f'{emojis[i]} - <@{player.id}>\n'
-                i += 1
-            embed = self.player_veto_embed(message_text=message_text, players_text=players_text, team1=team1,
+        if random_teams:
+            shuffle(players)
+            team1 = players[:len(players) // 2]
+            team2 = players[len(players) // 2:]
+            team1_captain = team1[0]
+            team2_captain = team2[0]
+            message_text = 'Random Teams'
+            message = await ctx.send(message_text)
+            embed = self.player_veto_embed(message_text=message_text, players_text='Random Teams', team1=team1,
                                            team1_captain=team1_captain, team2=team2, team2_captain=team2_captain)
             await message.edit(content=message_text, embed=embed)
-            if len(emoji_remove) > 0:
-                for emoji in emoji_remove:
-                    await message.clear_reaction(emoji)
-                emoji_remove = []
+        else:
+            emojis = emoji_bank.copy()
+            del emojis[len(players) - 2:len(emojis)]
+            emojis_selected = []
+            team1 = []
+            team2 = []
+            team1_captain = players[randint(0, len(players) - 1)]
+            team1.append(team1_captain)
+            players.remove(team1_captain)
+            team2_captain = players[randint(0, len(players) - 1)]
+            team2.append(team2_captain)
+            players.remove(team2_captain)
 
-            selected_players = 0
-            seconds = 0
-            while True:
-                await asyncio.sleep(1)
-                message = await ctx.fetch_message(message.id)
+            current_team_player_select = 1
 
-                for reaction in message.reactions:
-                    users = await reaction.users().flatten()
-                    if current_captain in users and selected_players < player_veto[player_veto_count] and not (
-                            reaction.emoji in emojis_selected):
-                        index = emojis.index(reaction.emoji)
+            current_captain = team1_captain
+            player_veto_count = 0
+
+            message = await ctx.send('10 man time\nLoading player selection...')
+            for emoji in emojis:
+                await message.add_reaction(emoji)
+
+            emoji_remove = []
+
+            while len(players) > 0:
+                message_text = ''
+                players_text = ''
+
+                if current_team_player_select == 1:
+                    message_text += f'<@{team1_captain.id}>'
+                    current_captain = team1_captain
+                elif current_team_player_select == 2:
+                    message_text += f'<@{team2_captain.id}>'
+                    current_captain = team2_captain
+
+                message_text += f' select {player_veto[player_veto_count]}\n'
+                message_text += 'You have 60 seconds to choose your player(s)\n'
+
+                i = 0
+                for player in players:
+                    players_text += f'{emojis[i]} - <@{player.id}>\n'
+                    i += 1
+                embed = self.player_veto_embed(message_text=message_text, players_text=players_text, team1=team1,
+                                               team1_captain=team1_captain, team2=team2, team2_captain=team2_captain)
+                await message.edit(content=message_text, embed=embed)
+                if len(emoji_remove) > 0:
+                    for emoji in emoji_remove:
+                        await message.clear_reaction(emoji)
+                    emoji_remove = []
+
+                selected_players = 0
+                seconds = 0
+                while True:
+                    await asyncio.sleep(1)
+                    message = await ctx.fetch_message(message.id)
+
+                    for reaction in message.reactions:
+                        users = await reaction.users().flatten()
+                        if current_captain in users and selected_players < player_veto[player_veto_count] and not (
+                                reaction.emoji in emojis_selected):
+                            index = emojis.index(reaction.emoji)
+                            if current_team_player_select == 1:
+                                team1.append(players[index])
+                            if current_team_player_select == 2:
+                                team2.append(players[index])
+                            emojis_selected.append(reaction.emoji)
+                            emoji_remove.append(reaction.emoji)
+                            del emojis[index]
+                            del players[index]
+                            selected_players += 1
+
+                    seconds += 1
+
+                    if seconds % 60 == 0:
+                        for _ in range(0, player_veto[player_veto_count]):
+                            index = randint(0, len(players) - 1)
+                            if current_team_player_select == 1:
+                                team1.append(players[index])
+                            if current_team_player_select == 2:
+                                team2.append(players[index])
+                            emojis_selected.append(emojis[index])
+                            del emojis[index]
+                            del players[index]
+                            selected_players += 1
+
+                    if selected_players == player_veto[player_veto_count]:
                         if current_team_player_select == 1:
-                            team1.append(players[index])
-                        if current_team_player_select == 2:
-                            team2.append(players[index])
-                        emojis_selected.append(reaction.emoji)
-                        emoji_remove.append(reaction.emoji)
-                        del emojis[index]
-                        del players[index]
-                        selected_players += 1
+                            current_team_player_select = 2
+                        elif current_team_player_select == 2:
+                            current_team_player_select = 1
+                        break
 
-                seconds += 1
+                player_veto_count += 1
 
-                if seconds % 60 == 0:
-                    for _ in range(0, player_veto[player_veto_count]):
-                        index = randint(0, len(players) - 1)
-                        if current_team_player_select == 1:
-                            team1.append(players[index])
-                        if current_team_player_select == 2:
-                            team2.append(players[index])
-                        emojis_selected.append(emojis[index])
-                        del emojis[index]
-                        del players[index]
-                        selected_players += 1
-
-                if selected_players == player_veto[player_veto_count]:
-                    if current_team_player_select == 1:
-                        current_team_player_select = 2
-                    elif current_team_player_select == 2:
-                        current_team_player_select = 1
-                    break
-
-            player_veto_count += 1
-
-        message_text = 'Map Veto Loading'
+        if map_arg is None:
+            message_text = 'Map Veto Loading'
+        else:
+            message_text = f'Map is `{map_arg}`'
         players_text = 'None'
         embed = self.player_veto_embed(message_text=message_text, players_text=players_text, team1=team1,
                                        team1_captain=team1_captain, team2=team2, team2_captain=team2_captain)
@@ -167,7 +206,7 @@ class CSGO(commands.Cog):
             team1_channel = await ctx.guild.create_voice_channel(name=f'team_{team1_captain.display_name}',
                                                                  user_limit=7)
             team2_channel = await ctx.guild.create_voice_channel(name=f'team_{team2_captain.display_name}',
-                                                                          user_limit=7)
+                                                                 user_limit=7)
         else:
             team1_channel = await ctx.author.voice.channel.category.create_voice_channel(
                 name=f'team_{team1_captain.display_name}', user_limit=7)
@@ -186,7 +225,10 @@ class CSGO(commands.Cog):
                                       {"player": str(player.id)})
             team2_steamIDs.append(data[0])
 
-        map_list = await self.map_veto(ctx, team1_captain, team2_captain)
+        if map_arg is None:
+            map_list = await self.map_veto(ctx, team1_captain, team2_captain)
+        else:
+            map_list = map_arg
 
         bot_ip = self.bot.web_server.IP
         if self.bot.bot_IP != "":
@@ -243,7 +285,6 @@ class CSGO(commands.Cog):
                                 players=team1 + team2, score_message=score_message)
         csgo_server.set_team_names(['team1', 'team2'])
         self.bot.web_server.add_server(csgo_server)
-
 
         if not self.pug.enabled:
             self.queue_check.start()
@@ -421,7 +462,7 @@ class CSGO(commands.Cog):
             if server.available:
                 available = True
                 break
-        if len(self.bot.queue_voice_channel.members) >= 10 and available:
+        if (len(self.bot.queue_voice_channel.members) >= 10 or (self.bot.dev and len(self.bot.queue_voice_channel.members) >= 1)) and available:
             embed = discord.Embed()
             embed.add_field(name='You have 60 seconds to ready up!', value='Ready: ✅', inline=False)
             ready_up_message = await self.bot.queue_ctx.send(embed=embed)

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -199,8 +199,9 @@ class CSGO(commands.Cog):
         await message.edit(content=message_text, embed=embed)
         await message.clear_reactions()
 
-        chosen_map_embed = await self.get_chosen_map_embed(map_arg)
-        await ctx.send(embed=chosen_map_embed)
+        if map_arg is not None:
+            chosen_map_embed = await self.get_chosen_map_embed(map_arg)
+            await ctx.send(embed=chosen_map_embed)
 
         team1_steamIDs = []
         team2_steamIDs = []

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -13,7 +13,8 @@ class Setup(commands.Cog):
     def __init__(self, bot: Discord_10man):
         self.bot: Discord_10man = bot
 
-    @commands.command(help='This command connects users steam account to the bot.',
+    @commands.command(aliases=['login'],
+                      help='This command connects users steam account to the bot.',
                       brief='Connect your SteamID to the bot', usage='<SteamID or CommunityURL>')
     async def link(self, ctx: commands.Context, steamID_input: str):
         steamID = SteamID(steamID_input)
@@ -42,7 +43,7 @@ class Setup(commands.Cog):
                       help='Command to set the server for the queue system. You must be in a voice channel.',
                       brief='Set\'s the server for the queue')
     @commands.check(checks.voice_channel)
-    async def setup_queue(self, ctx: commands.Context, enabled: bool = False):
+    async def setup_queue(self, ctx: commands.Context, enabled: bool = True):
         self.bot.queue_voice_channel = ctx.author.voice.channel
         self.bot.queue_ctx = ctx
         if enabled:


### PR DESCRIPTION
Closes #72 
- Added optional arguments for setup queue
   - `random` - randomizes teams
   - `map` - select the map to play on
   - Examples:
      - `.pug random` - a pug with a map veto but random teams
      - `.pug de_dust2` - a pug on de_dust2 with a player veto 
      - `.pug random de_dust2` - a pug with random teams on de_dust2
      - `.pug de_dust2 random` - a pug with random teams on de_dust2
- Added `.login` as alias for `.link`
- Changed default for setup queue to be enabled instead of disabled when calling the command with no arguments
- Added dev feature for queue if dev bot ID is set