### PR TITLE
Fixes to 1.5.0-beta

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -41,6 +41,7 @@ class Discord_10man(commands.Bot):
         self.match_size = 10
         self.spectators: List[discord.Member] = []
         self.connect_dm = False
+        self.queue_captains: List[discord.Member] = []
 
         logger = logging.getLogger('discord')
         logger.setLevel(logging.DEBUG)

--- a/bot.py
+++ b/bot.py
@@ -8,7 +8,7 @@ from utils.server import WebServer
 from utils.csgo_server import CSGOServer
 
 
-__version__ = '1.5.0-beta'
+__version__ = '1.5.1-beta'
 __dev__ = 745000319942918303
 
 class Discord_10man(commands.Bot):

--- a/checks.py
+++ b/checks.py
@@ -52,3 +52,8 @@ async def active_game(ctx: commands.Context):
     if not active:
         raise commands.CommandError(message='There are no live matches')
     return True
+
+
+async def queue_running(ctx: commands.Context):
+    if ctx.bot.cogs['CSGO'].queue_check.is_running():
+        raise commands.CommandError(message='Queue not running.')

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -84,11 +84,9 @@ class CSGO(commands.Cog):
 
         if not self.pug.enabled:
             if len(self.bot.queue_captains) > 0:
-                team1_captain_arg = self.bot.queue_captains[0]
-                self.bot.queue_captains.remove(team1_captain_arg)
+                team1_captain_arg = self.bot.queue_captains.pop(0)
             if len(self.bot.queue_captains) > 0:
-                team2_captain_arg = self.bot.queue_captains[0]
-                self.bot.queue_captains.remove(team2_captain_arg)
+                team2_captain_arg = self.bot.queue_captains.pop(0)
 
         # TODO: Refactor this mess
         db = Database('sqlite:///main.sqlite')

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -27,8 +27,8 @@ current_map_pool = active_map_pool.copy()
 
 emoji_bank = ['0️⃣', '1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟']
 
-# Veto style 1 2 2 2 1, last two 1s are for if we are playing with coaches
-player_veto = [1, 2, 2, 2, 1, 1, 1]
+# Veto style 1 2 2 2 1 1 1, last two 1s are for if we are playing with coaches
+
 
 EU_ISO = ['AT', 'BE', 'BG', 'HR', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'NL',
           'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE']
@@ -138,6 +138,16 @@ class CSGO(commands.Cog):
                 await message.add_reaction(emoji)
 
             emoji_remove = []
+
+            player_veto = []
+            if self.bot.match_size == 2:
+                player_veto = [1, 1]
+            for i in range(self.bot.match_size - 2):
+                if i == 0 or i == self.bot.match_size - 3:
+                    player_veto.append(1)
+                elif i % 2 == 0:
+                    player_veto.append(2)
+            player_veto = player_veto + [1, 1]
 
             while len(players) > 0:
                 message_text = ''

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -82,6 +82,14 @@ class CSGO(commands.Cog):
                 else:
                     raise commands.CommandError(message=f'Invalid Argument: `{arg}`')
 
+        if not self.pug.enabled:
+            if len(self.bot.queue_captains) > 0:
+                team1_captain_arg = self.bot.queue_captains[0]
+                self.bot.queue_captains.remove(team1_captain_arg)
+            if len(self.bot.queue_captains) > 0:
+                team2_captain_arg = self.bot.queue_captains[0]
+                self.bot.queue_captains.remove(team2_captain_arg)
+
         # TODO: Refactor this mess
         db = Database('sqlite:///main.sqlite')
         await db.connect()

--- a/cogs/csgo.py
+++ b/cogs/csgo.py
@@ -559,7 +559,7 @@ class CSGO(commands.Cog):
 
     @tasks.loop(seconds=5.0)
     async def queue_check(self):
-        print(self.bot.queue_voice_channel.members)
+
         available: bool = False
         for server in self.bot.servers:
             if server.available:
@@ -591,7 +591,8 @@ class CSGO(commands.Cog):
             if member not in user_reactions:
                 ready = False
             else:
-                self.bot.users_not_ready.remove(member)
+                if member in self.bot.users_not_ready:
+                    self.bot.users_not_ready.remove(member)
 
         if ready:
             self.readied_up = True

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -127,6 +127,8 @@ class Setup(commands.Cog):
         if size % 2 != 0:
             raise commands.CommandError(message=f'Match size must be an even number.')
         self.bot.match_size = size
+        if self.bot.cogs['CSGO'].queue_check.is_running():
+            self.bot.cogs['CSGO'].queue_check.restart()
         await ctx.send(f'Set match size to {self.bot.match_size}.')
 
     @setup_match_size.error

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -78,6 +78,13 @@ class Setup(commands.Cog):
             await ctx.send(str(error))
         traceback.print_exc()
 
+    @commands.command(aliases=['empty'],
+                      help='Empties the queue')
+    @commands.has_permissions(administrator=True)
+    async def empty_queue(self, ctx: commands.Context):
+        for member in self.bot.queue_voice_channel.members:
+            await member.move_to(channel=None, reason=f'Admin cleared the queue')
+
     @commands.command(aliases=['remove_spec'],
                       help='Removes this user as a spectator from the config.',
                       brief='Removes user as spectator', usage='<@User>')

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -93,6 +93,7 @@ class Setup(commands.Cog):
     @commands.command(aliases=['setupqueue'],
                       help='Command to set the server for the queue system. You must be in a voice channel.',
                       brief='Set\'s the server for the queue')
+    @commands.has_permissions(administrator=True)
     @commands.check(checks.voice_channel)
     async def setup_queue(self, ctx: commands.Context, enabled: bool = True):
         self.bot.queue_voice_channel = ctx.author.voice.channel
@@ -116,6 +117,18 @@ class Setup(commands.Cog):
         if isinstance(error, commands.CommandError):
             await ctx.send(str(error))
         traceback.print_exc()
+
+    @commands.command(aliases=['restart_queue'],
+                      help='The command forcefully restarts the queue.',
+                      brief='Restart\'s the queue')
+    @commands.has_permissions(administrator=True)
+    @commands.check(checks.queue_running)
+    async def force_restart_queue(self, ctx: commands.Context):
+        self.bot.cogs['CSGO'].queue_check.cancel()
+        self.bot.cogs['CSGO'].queue_check.start()
+        self.bot.cogs['CSGO'].pug.enabled = False
+        await ctx.send('Queue forcefully restarted')
+
 
     @commands.command(aliases=['setup_queue_size', 'match_size', 'queue_size', 'set_match_size', 'set_queue_size'],
                       help='This command sets the size of the match and the queue.',

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -68,7 +68,8 @@ class Setup(commands.Cog):
         data = await db.fetch_one('SELECT 1 FROM users WHERE discord_id = :spectator',
                                   {"spectator": str(spec.id)})
         if data is None:
-            raise commands.UserInputError(message=f'User did not `.link` their account and probably is not a spectator.')
+            raise commands.UserInputError(
+                message=f'User did not `.link` their account and probably is not a spectator.')
         if data[0] in self.bot.spectators:
             self.bot.spectators.remove(spec)
             await ctx.send(f'<@{spec.id}> was added as a spectator.')
@@ -129,6 +130,11 @@ class Setup(commands.Cog):
         self.bot.cogs['CSGO'].pug.enabled = False
         await ctx.send('Queue forcefully restarted')
 
+    @force_restart_queue.error
+    async def force_restart_queue_error(self, ctx: commands.Context, error: Exception):
+        if isinstance(error, commands.CommandError):
+            await ctx.send(str(error))
+        traceback.print_exc()
 
     @commands.command(aliases=['setup_queue_size', 'match_size', 'queue_size', 'set_match_size', 'set_queue_size'],
                       help='This command sets the size of the match and the queue.',
@@ -151,7 +157,6 @@ class Setup(commands.Cog):
         elif isinstance(error, commands.CommandError):
             await ctx.send(str(error))
         traceback.print_exc()
-
 
     @commands.command(help='Command to send a test message to the server to verify that RCON is working.',
                       brief='Sends a message to the server to test RCON', usage='<message>')
@@ -192,6 +197,7 @@ class Setup(commands.Cog):
     async def force_end(self, ctx: commands.Context, server_id: int = 0):
         valve.rcon.execute((self.bot.servers[server_id].server_address, self.bot.servers[server_id].server_port),
                            self.bot.servers[server_id].RCON_password, 'get5_endmatch')
+
 
 def setup(client):
     client.add_cog(Setup(client))

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -1,6 +1,7 @@
 import aiohttp
 import discord
 import checks
+import sys, os
 import traceback
 
 from bot import Discord_10man
@@ -78,6 +79,13 @@ class Utils(commands.Cog):
                         value=f'Built by <@125033487051915264> & <@282670937738969088>', inline=False)
         await ctx.send(embed=embed)
 
+    @commands.command(aliases=['r'], help='Restarts the bot')
+    @commands.command(hidden=True)
+    @commands.has_permissions(administrator=True)
+    async def restart(self, ctx: commands.Context):
+        await ctx.send('Restarting Bot')
+        python = sys.executable
+        os.execl(python, python, *sys.argv)
 
 def setup(client):
     client.add_cog(Utils(client))

--- a/utils/server.py
+++ b/utils/server.py
@@ -76,6 +76,7 @@ class WebServer:
                     break
 
             if server is not None:
+                round_16 = False
                 if get5_event['event'] == 'series_start':
                     server.set_team_names([get5_event['params']['team1_name'], get5_event['params']['team2_name']])
 
@@ -116,8 +117,10 @@ class WebServer:
                                               inline=False)
                     score_embed.set_footer(text="🟢 Live")
                     await server.score_message.edit(embed=score_embed)
+                    if get5_event["params"]["team1_score"] == 16 or get5_event["params"]["team2_score"]:
+                        round_16 = True
 
-                elif get5_event['event'] == 'series_end' or get5_event['event'] == 'series_cancel' or get5_event['event'] == 'map_end':
+                if get5_event['event'] == 'series_end' or get5_event['event'] == 'series_cancel' or get5_event['event'] == 'map_end' or round_16:
                     if get5_event['event'] == 'series_end':
                         await server.score_message.edit(content='Game Over')
                     elif get5_event['event'] == 'series_cancel':

--- a/utils/server.py
+++ b/utils/server.py
@@ -117,7 +117,7 @@ class WebServer:
                                               inline=False)
                     score_embed.set_footer(text="🟢 Live")
                     await server.score_message.edit(embed=score_embed)
-                    if get5_event["params"]["team1_score"] == 16 or get5_event["params"]["team2_score"]:
+                    if get5_event["params"]["team1_score"] == 16 or get5_event["params"]["team2_score"] == 16:
                         round_16 = True
 
                 if get5_event['event'] == 'series_end' or get5_event['event'] == 'series_cancel' or get5_event['event'] == 'map_end' or round_16:


### PR DESCRIPTION
- Player veto count now is based off of match size
- Restarts the queue when the size of the queue is changed
- Add command to forcefully restart the queue
- Added the option to set queue captains
   - You can set as many as you'd like, just tag them, once they have been a captain, they will be removed from the queue captains list.
- Added a command to restart the whole bot. Only use this if it breaks, I would not recommend using it though and I would say restart the bot with the code manually bc this will create a process that is hard to find, but the option is there if you need it.
- Added a command to kick everyone from the queue
- Added a check for the end of round 16 to speed up the ending of games

Closes #83 