### PR TITLE
1.6.0

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -8,12 +8,11 @@ from utils.server import WebServer
 from utils.csgo_server import CSGOServer
 
 
-__version__ = '1.5.4-beta'
+__version__ = '1.6.0'
 __dev__ = 745000319942918303
 
 class Discord_10man(commands.Bot):
     def __init__(self, config: dict, startup_extensions: List[str]):
-        # TODO: Change prefix to . when syncing
         # commands.when_mentioned_or('e!')
         super().__init__(command_prefix='.', case_insensitive=True, description='A bot to run CSGO PUGS.',
                          help_command=commands.DefaultHelpCommand(verify_checks=False),
@@ -25,6 +24,10 @@ class Discord_10man(commands.Bot):
                          ))
         self.token: str = config['discord_token']
         self.bot_IP: str = config['bot_IP']
+        if 'bot_port' in config:
+            self.bot_port: int = config['bot_port']
+        else:
+            self.bot_port: int = 3000
         self.steam_web_api_key = config['steam_web_API_key']
         self.servers: List[CSGOServer] = []
         # Will need to change for when there is multiple server queue

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -112,7 +112,6 @@ class Setup(commands.Cog):
     @commands.command(aliases=['dm'],
                       help='Command to enable or disable sending a dm with the connect ip vs posting it in the channel',
                       brief='Enable or disable connect via dm')
-    @commands.check(checks.voice_channel)
     @commands.has_permissions(administrator=True)
     async def connect_dm(self, ctx: commands.Context, enabled: bool = False):
         self.bot.connect_dm = enabled

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -224,6 +224,12 @@ class Setup(commands.Cog):
         valve.rcon.execute((self.bot.servers[server_id].server_address, self.bot.servers[server_id].server_port),
                            self.bot.servers[server_id].RCON_password, 'get5_endmatch')
 
+    @force_end.error
+    async def force_end_error(self, ctx: commands.Context, error: Exception):
+        if isinstance(error, commands.MissingPermissions):
+            await ctx.send('Only an administrator can force end a match.')
+        traceback.print_exc()
+
 
 def setup(client):
     client.add_cog(Setup(client))

--- a/config_example.json
+++ b/config_example.json
@@ -1,6 +1,7 @@
 {
     "discord_token": "123fkdjsh123alksjfhlaskdjafhlkj1hl3kj4hlkjss",
     "bot_IP": "",
+    "bot_port": 3000,
     "steam_web_API_key": "123ABDKLK12938712938SBDDS1723987",
     "servers": [
         {


### PR DESCRIPTION
- Fixed player size to be the size of the match
- Fixed map arg to be passed as an array rather than a string
- Fixed players per team to be half the match size
- Fixed RCON error with non unicode names
- Added optional port in config
- Removed extra voting for captains. If you want to play with captains, set the match size to 12.
- Fixed bug in moving players if the operation fails
- Added error message to force end
- Removed voice channel check for dm message.