### PR TITLE
Added check to see if Steam ID is already linked

### DIFF
--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -34,6 +34,13 @@ class Setup(commands.Cog):
                     raise commands.UserInputError(message='Please enter a valid SteamID or community url.')
         db = Database('sqlite:///main.sqlite')
         await db.connect()
+
+        q = "SELECT * FROM users WHERE steam_id = :steam_id"
+        result = await db.fetch_one(query=q, values={"steam_id": steamID.as_steam2_zero})
+
+        if result != []:
+            raise commands.UserInputError(message='This SteamID is already linked to someone.')
+
         await db.execute('''
                         REPLACE INTO users (discord_id, steam_id)
                         VALUES( :discord_id, :steam_id )

--- a/cogs/setup.py
+++ b/cogs/setup.py
@@ -36,7 +36,7 @@ class Setup(commands.Cog):
         await db.connect()
 
         q = "SELECT * FROM users WHERE steam_id = :steam_id"
-        result = await db.fetch_one(query=q, values={"steam_id": steamID.as_steam2_zero})
+        result = await db.fetch_all(query=q, values={"steam_id": steamID.as_steam2_zero})
 
         if result != []:
             raise commands.UserInputError(message='This SteamID is already linked to someone.')


### PR DESCRIPTION
#124 

Implemented a simple check to disallow users to use the link command if the provided Steam ID is already linked to someone. 

Let me know if there's anything you'd like changed before merging.